### PR TITLE
Fix the UnsupportedOperationException with implicit grant

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/OAuthTokenIssuanceDASDataPublisher.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/OAuthTokenIssuanceDASDataPublisher.java
@@ -143,7 +143,8 @@ public class OAuthTokenIssuanceDASDataPublisher extends AbstractOAuthEventInterc
             tokenData.setRefreshTokenValidityMillis(tokenDO.getRefreshTokenValidityPeriodInMillis());
             tokenData.setIssuedTime(tokenDO.getIssuedTime().getTime());
         }
-        List<String> requestedScopes = Arrays.asList(oauthAuthzMsgCtx.getAuthorizationReqDTO().getScopes());
+        List<String> requestedScopes = new LinkedList(Arrays.asList(oauthAuthzMsgCtx.getAuthorizationReqDTO().
+                getScopes()));
         List<String> grantedScopes = Arrays.asList(respDTO.getScope());
         requestedScopes.removeAll(grantedScopes);
         for (String scope : requestedScopes) {


### PR DESCRIPTION
### Proposed changes in this pull request
Arrays.asList returns a List wrapper around an array. This wrapper has a fixed size and is directly backed by the array, and as such calls to set will modify the array, and any other method that modifies the list will throw an UnsupportedOperationException. Hence created a new modifiable list by copying the wrapper list's contents