### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/OAuthDataPublisherUtils.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/OAuthDataPublisherUtils.java
@@ -27,7 +27,7 @@ import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientExcepti
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDAO;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
-import org.wso2.carbon.identity.oauth2.dao.TokenMgtDAO;
+import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
@@ -75,8 +75,8 @@ public class OAuthDataPublisherUtils {
 
     public static AccessTokenDO getTokenData(String token) throws IdentityOAuth2Exception,
             InvalidOAuthClientException {
-        TokenMgtDAO tokenMgtDAO = new TokenMgtDAO();
-        return tokenMgtDAO.retrieveAccessToken(token, true);
+
+        return OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO().getAccessToken(token, true);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -180,8 +180,8 @@
     <properties>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
-        <identity.inbound.auth.oauth.version>6.4.71</identity.inbound.auth.oauth.version>
-        <identity.framework.version>5.14.67</identity.framework.version>
+        <identity.inbound.auth.oauth.version>7.0.0</identity.inbound.auth.oauth.version>
+        <identity.framework.version>6.0.0</identity.framework.version>
         <carbon.analytics-common.version>5.2.10</carbon.analytics-common.version>
         <carbon.p2.plugin.version>5.2.3</carbon.p2.plugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
@@ -189,8 +189,8 @@
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
 
         <carbon.kernel.imp.pkg.version.range>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
-        <identity.framework.imp.pkg.version.range>[5.14.0, 6.0.0)</identity.framework.imp.pkg.version.range>
-        <identity.inbound.auth.oauth.imp.pkg.version.range>[6.2.0, 7.0.0)</identity.inbound.auth.oauth.imp.pkg.version.range>
+        <identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)</identity.framework.imp.pkg.version.range>
+        <identity.inbound.auth.oauth.imp.pkg.version.range>[7.0.0, 8.0.0)</identity.inbound.auth.oauth.imp.pkg.version.range>
         <carbon.analytics-common.imp.pkg.version.range>[5.2.0,6.0.0)</carbon.analytics-common.imp.pkg.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

The `TokenMgtDAO` class of identity-inbound-auth-oauth repo is deprecated and removed from the latest version. 

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16