### PR TITLE
Mask initiator in listeners

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/pom.xml
@@ -66,6 +66,10 @@
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -102,6 +106,7 @@
                             org.wso2.carbon.databridge.commons; version="${carbon.analytics-common.version}",
                             com.google.gson;version="${com.google.code.gson.osgi.version.range}",
                             org.wso2.carbon.user.core.*;version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils; version="${identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.data.publisher.oauth.internal,

--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/PasswordGrantAuditLogger.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/PasswordGrantAuditLogger.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.data.publisher.oauth.listener;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
@@ -31,6 +32,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 
 import java.util.Map;
 
@@ -78,6 +80,16 @@ public class PasswordGrantAuditLogger extends AbstractOAuthEventInterceptor {
             auditResult = FrameworkConstants.AUDIT_SUCCESS;
         } else {
             auditResult = FrameworkConstants.AUDIT_FAILED;
+        }
+
+        if (LoggerUtils.isLogMaskingEnable) {
+            String maskedUsername = LoggerUtils.getMaskedContent(requestInitiator);
+            if (StringUtils.isNotBlank(requestInitiator) && StringUtils.isNotBlank(authenticatedUserTenantDomain)) {
+                requestInitiator = IdentityUtil.getInitiatorId(requestInitiator, authenticatedUserTenantDomain);
+            }
+            if (StringUtils.isBlank(requestInitiator)) {
+                requestInitiator = maskedUsername;
+            }
         }
 
         String auditData = "\"" + "AuthenticatedUser" + "\" : \"" + authenticatedSubjectIdentifier

--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/PasswordGrantAuditLogger.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/PasswordGrantAuditLogger.java
@@ -83,7 +83,8 @@ public class PasswordGrantAuditLogger extends AbstractOAuthEventInterceptor {
         }
 
         if (LoggerUtils.isLogMaskingEnable) {
-            if (StringUtils.isNotBlank(requestInitiator) && StringUtils.isNotBlank(authenticatedUserTenantDomain)) {
+            if (StringUtils.isNotBlank(requestInitiator) && StringUtils.isNotBlank(authenticatedUserTenantDomain) &&
+                    !authenticatedUserTenantDomain.equals("N/A")) {
                 requestInitiator = IdentityUtil.getInitiatorId(requestInitiator, authenticatedUserTenantDomain);
             }
             if (StringUtils.isBlank(requestInitiator)) {

--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/PasswordGrantAuditLogger.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/PasswordGrantAuditLogger.java
@@ -83,12 +83,11 @@ public class PasswordGrantAuditLogger extends AbstractOAuthEventInterceptor {
         }
 
         if (LoggerUtils.isLogMaskingEnable) {
-            String maskedUsername = LoggerUtils.getMaskedContent(requestInitiator);
             if (StringUtils.isNotBlank(requestInitiator) && StringUtils.isNotBlank(authenticatedUserTenantDomain)) {
                 requestInitiator = IdentityUtil.getInitiatorId(requestInitiator, authenticatedUserTenantDomain);
             }
             if (StringUtils.isBlank(requestInitiator)) {
-                requestInitiator = maskedUsername;
+                requestInitiator = LoggerUtils.getMaskedContent(requestInitiator);
             }
         }
 

--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/SAML2BearerGrantAuditLogger.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/SAML2BearerGrantAuditLogger.java
@@ -18,9 +18,11 @@
 
 package org.wso2.carbon.identity.data.publisher.oauth.listener;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
 import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -76,6 +78,16 @@ public class SAML2BearerGrantAuditLogger extends AbstractOAuthEventInterceptor {
             authenticatedUserTenantDomain = tokReqMsgCtx.getAuthorizedUser().getTenantDomain();
             auditResult = FrameworkConstants.AUDIT_SUCCESS;
 
+            if (LoggerUtils.isLogMaskingEnable) {
+                String maskedUsername = LoggerUtils.getMaskedContent(requestInitiator);
+                if (StringUtils.isNotBlank(requestInitiator) && StringUtils.isNotBlank(authenticatedUserTenantDomain)) {
+                    requestInitiator = IdentityUtil.getInitiatorId(requestInitiator, authenticatedUserTenantDomain);
+                }
+                if (StringUtils.isBlank(requestInitiator)) {
+                    requestInitiator = maskedUsername;
+                }
+            }
+
             String auditData = "\"" + "AuthenticatedUser" + "\" : \"" + authenticatedSubjectIdentifier
                     + "\",\"" + "AuthenticatedUserStoreDomain" + "\" : \"" + authenticatedUserStoreDomain
                     + "\",\"" + "AuthenticatedUserTenantDomain" + "\" : \"" + authenticatedUserTenantDomain
@@ -92,6 +104,9 @@ public class SAML2BearerGrantAuditLogger extends AbstractOAuthEventInterceptor {
                     auditResult)
             );
         } else {
+            if (LoggerUtils.isLogMaskingEnable) {
+                requestInitiator = LoggerUtils.getMaskedContent(requestInitiator);
+            }
             auditResult = FrameworkConstants.AUDIT_FAILED;
             String error = "Error Description :" + tokenRespDTO.getErrorMsg() + "Error Type :" +
                     tokenRespDTO.getErrorCode();

--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/SAML2BearerGrantAuditLogger.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/SAML2BearerGrantAuditLogger.java
@@ -79,12 +79,11 @@ public class SAML2BearerGrantAuditLogger extends AbstractOAuthEventInterceptor {
             auditResult = FrameworkConstants.AUDIT_SUCCESS;
 
             if (LoggerUtils.isLogMaskingEnable) {
-                String maskedUsername = LoggerUtils.getMaskedContent(requestInitiator);
                 if (StringUtils.isNotBlank(requestInitiator) && StringUtils.isNotBlank(authenticatedUserTenantDomain)) {
                     requestInitiator = IdentityUtil.getInitiatorId(requestInitiator, authenticatedUserTenantDomain);
                 }
                 if (StringUtils.isBlank(requestInitiator)) {
-                    requestInitiator = maskedUsername;
+                    requestInitiator = LoggerUtils.getMaskedContent(requestInitiator);
                 }
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${identity.framework.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -181,7 +186,7 @@
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <identity.inbound.auth.oauth.version>6.4.71</identity.inbound.auth.oauth.version>
-        <identity.framework.version>5.14.67</identity.framework.version>
+        <identity.framework.version>5.25.76</identity.framework.version>
         <carbon.analytics-common.version>5.2.10</carbon.analytics-common.version>
         <carbon.p2.plugin.version>5.2.3</carbon.p2.plugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>


### PR DESCRIPTION
This PR fixes: 
`TID: [1] [2022-12-13 11:13:31,099] [30e1fdd2-5dcd-4c6b-8776-59a6f0e8de1a]  INFO {AUDIT_LOG} - **Initiator : vivek@gmail.com@testasgardeo1** | Action : PostTokenIssue | Target : PasswordGrantAuditLogger | Data : { "AuthenticatedUser" : "0c2bfb1f-1b9d-477c-a97e-71a104e7522d","AuthenticatedUserStoreDomain" : "DEFAULT","AuthenticatedUserTenantDomain" : "testasgardeo1","ServiceProvider" : "Sample App","RequestType" : "oidc","RelyingParty" : "n2q91fnqOzt7UZdgHnAuwpZYwUMa" } | Result : Success `

