### PR TITLE
Add new field to publish remoteIp of user on token issuance

### DIFF
--- a/components/org.wso2.carbon.identity.data.publisher.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/pom.xml
@@ -111,6 +111,7 @@
                             com.google.gson;version="${com.google.code.gson.osgi.version.range}",
                             org.wso2.carbon.user.core.*;version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.identity.central.log.mgt.utils; version="${identity.framework.imp.pkg.version.range}",
+                            javax.servlet.http; version="${imp.pkg.version.javax.servlet}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.data.publisher.oauth.internal,

--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/OAuthTokenIssuanceDASDataPublisher.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/OAuthTokenIssuanceDASDataPublisher.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequestWrapper;
 
 /**
  * Oauth Event Interceptor implemented for publishing oauth data to DAS
@@ -102,7 +103,10 @@ public class OAuthTokenIssuanceDASDataPublisher extends AbstractOAuthEventInterc
         tokenData.setAuthzScopes(tokenRespDTO.getAuthorizedScopes());
         tokenData.setUnAuthzScopes(unauthzScopes.toString());
         tokenData.setAccessTokenValidityMillis(tokenRespDTO.getExpiresInMillis());
-
+        HttpServletRequestWrapper tokenReq = tokenReqDTO.getHttpServletRequestWrapper();
+        if (tokenReq != null) {
+            tokenData.setRemoteIp(tokenReq.getRemoteAddr());
+        }
         tokenData.addParameter(OAuthDataPublisherConstants.TENANT_ID, publishingTenantDomains);
         this.publishTokenIssueEvent(tokenData);
     }
@@ -129,6 +133,11 @@ public class OAuthTokenIssuanceDASDataPublisher extends AbstractOAuthEventInterc
             if (oauthAuthzMsgCtx.getAuthorizationReqDTO() != null) {
                 publishingTenantDomains = OAuthDataPublisherUtils.getTenantDomains(oauthAuthzMsgCtx
                         .getAuthorizationReqDTO().getTenantDomain(), user.getTenantDomain());
+                HttpServletRequestWrapper authzRequest = oauthAuthzMsgCtx.getAuthorizationReqDTO()
+                        .getHttpServletRequestWrapper();
+                if (authzRequest != null) {
+                    tokenData.setRemoteIp(authzRequest.getRemoteAddr());
+                }
             } else {
                 publishingTenantDomains = OAuthDataPublisherUtils.getTenantDomains(null, user.getTenantDomain());
             }
@@ -174,7 +183,7 @@ public class OAuthTokenIssuanceDASDataPublisher extends AbstractOAuthEventInterc
 
     public void publishTokenIssueEvent(TokenData tokenData) {
 
-        Object[] payloadData = new Object[14];
+        Object[] payloadData = new Object[15];
         payloadData[0] = tokenData.getUser();
         payloadData[1] = tokenData.getTenantDomain();
         payloadData[2] = tokenData.getUserStoreDomain();
@@ -189,6 +198,7 @@ public class OAuthTokenIssuanceDASDataPublisher extends AbstractOAuthEventInterc
         payloadData[11] = tokenData.getAccessTokenValidityMillis();
         payloadData[12] = tokenData.getRefreshTokenValidityMillis();
         payloadData[13] = tokenData.getIssuedTime();
+        payloadData[14] = tokenData.getRemoteIp();
 
         String[] publishingDomains = (String[]) tokenData.getParameter(OAuthDataPublisherConstants.TENANT_ID);
         if (publishingDomains != null && publishingDomains.length > 0) {

--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/OAuthTokenIssuanceDASDataPublisher.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/listener/OAuthTokenIssuanceDASDataPublisher.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
 import javax.servlet.http.HttpServletRequestWrapper;
 
 /**

--- a/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/model/TokenData.java
+++ b/components/org.wso2.carbon.identity.data.publisher.oauth/src/main/java/org/wso2/carbon/identity/data/publisher/oauth/model/TokenData.java
@@ -42,6 +42,7 @@ public class TokenData<T1 extends Object, T2 extends Object> {
     private long issuedTime;
     private boolean isActive;
     private long revokedTime;
+    private String remoteIp;
     protected Map<T1, T2> parameters = new HashMap<>();
 
     public String getUser() {
@@ -170,6 +171,16 @@ public class TokenData<T1 extends Object, T2 extends Object> {
 
     public void setRevokedTime(long revokedTime) {
         this.revokedTime = revokedTime;
+    }
+
+    public String getRemoteIp() {
+
+        return remoteIp;
+    }
+
+    public void setRemoteIp(String remoteIp) {
+
+        this.remoteIp = remoteIp;
     }
 
     public void addParameter(T1 key, T2 value) {

--- a/features/org.wso2.carbon.identity.data.publisher.oauth.server.feature/resources/org.wso2.is.analytics.stream.OauthTokenIssuance_1.0.0.json
+++ b/features/org.wso2.carbon.identity.data.publisher.oauth.server.feature/resources/org.wso2.is.analytics.stream.OauthTokenIssuance_1.0.0.json
@@ -65,6 +65,10 @@
     {
       "name": "issuedTime",
       "type": "LONG"
+    },
+    {
+      "name": "remoteIp",
+      "type": "STRING"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,7 @@
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <com.google.code.gson.osgi.version.range>[2.6.2,3.0.0)</com.google.code.gson.osgi.version.range>
+        <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <properties>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
-        <identity.inbound.auth.oauth.version>6.11.151</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.11.188</identity.inbound.auth.oauth.version>
         <identity.framework.version>5.25.325</identity.framework.version>
         <carbon.analytics-common.version>5.2.10</carbon.analytics-common.version>
         <carbon.p2.plugin.version>5.2.3</carbon.p2.plugin.version>


### PR DESCRIPTION
### Purpose
- Add new field to publish remoteIp of user on token issuance

### Related Issue
- https://github.com/wso2/product-is/issues/17131

### Depends on
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2247
